### PR TITLE
Update WindowListener.java

### DIFF
--- a/src/main/java/net/craftsupport/anticrasher/packet/WindowListener.java
+++ b/src/main/java/net/craftsupport/anticrasher/packet/WindowListener.java
@@ -50,7 +50,7 @@ public class WindowListener implements PacketListener {
 
         if (event.getPacketType() == PacketType.Play.Client.EDIT_BOOK) {
             WrapperPlayClientEditBook editBook = new WrapperPlayClientEditBook(event);
-            if (editBook.getTitle().length() > 32) {
+            if (editBook.getTitle() == null || editBook.getTitle().length() > 32) {
                 handleInvalidPacket(event);
             }
         }


### PR DESCRIPTION
in the EDIT_BOOK packet handling, a null check for the book title is added. This change prevents potential NullPointerExceptions that could be used to crash the server